### PR TITLE
Pass headers when storing an exported table

### DIFF
--- a/synapsebridgehelpers/export_tables.py
+++ b/synapsebridgehelpers/export_tables.py
@@ -415,7 +415,7 @@ def export_tables(syn, table_mapping, source_tables=None, target_project=None,
                     source_table = source_table,
                     target_table = target_table)
             try: # error after updating schema -> data may be lost on Synapse
-                if len(schema_comparison.values()):
+                if sum(list(map(len, schema_comparison.values()))) > 0:
                     synchronize_schemas(
                             syn,
                             schema_comparison = schema_comparison,

--- a/synapsebridgehelpers/export_tables.py
+++ b/synapsebridgehelpers/export_tables.py
@@ -115,10 +115,11 @@ def _store_dataframe_to_table(syn, df, df_cols, table_id=None, parent_id=None,
         target_table = sc.Table(
                 schema = target_table_schema,
                 values = sanitized_dataframe)
-        target_table = syn.store(target_table, **kwargs)
+        target_table = syn.store(target_table, headers = df_cols, **kwargs)
     else:
-        target_table = syn.store(sc.Table(table_id, sanitized_dataframe),
-                                 **kwargs)
+        target_table = syn.store(
+                sc.Table(table_id, sanitized_dataframe, headers = df_cols),
+                **kwargs)
     return target_table
 
 
@@ -429,7 +430,7 @@ def export_tables(syn, table_mapping, source_tables=None, target_project=None,
                     target_table = target_table.rename(
                             schema_comparison["renamed"], axis = 1)
                     target_table = _sanitize_dataframe(syn, target_table, target)
-                    syn.store(sc.Table(target, target_table))
+                    syn.store(sc.Table(target, target_table, headers = source_cols))
             except Exception as e:
                 dump_on_error(target_table, e, syn, source, target)
             if update:


### PR DESCRIPTION
Fixes #16 

Because of [outstanding issues with the synapse python client / pandas](https://sagebionetworks.jira.com/browse/SYNPY-630) we need to type cast [certain synapse column types](https://github.com/Sage-Bionetworks/synapsebridgehelpers/blob/master/synapsebridgehelpers/export_tables.py#L73) to strings within the pandas dataframe before storing.

For reasons I don't fully understand, this causes the new synapse client to break (traceback included below). To short-circuit the new synapse client's logic, we need to manually pass the headers of our tables which, luckily, we usually already had available to us within synapsebridgehelpers.

I've also included a fix where we previously called `synchronize_schemas` though the schemas were the same.

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-46-7b0f3a118eab> in <module>
----> 1 target_table = syn.store(sc.Table(target, sanitized_dataframe), used = [source])

~/miniconda3/lib/python3.7/site-packages/synapseclient/table.py in Table(schema, values, **kwargs)
   1259     # pandas DataFrame
   1260     elif pandas_available and isinstance(values, pd.DataFrame):
-> 1261         return CsvFileTable.from_data_frame(schema, values, **kwargs)
   1262 
   1263     # dict

~/miniconda3/lib/python3.7/site-packages/synapseclient/table.py in from_data_frame(cls, schema, df, filepath, etag, quoteCharacter, escapeCharacter, lineEnd, separator, header, includeRowIdAndRowVersion, headers, **kwargs)
   1609         # infer columns from data frame if not specified
   1610         if not headers:
-> 1611             cols = as_table_columns(df)
   1612             headers = [SelectColumn.from_column(col) for col in cols]
   1613 

~/miniconda3/lib/python3.7/site-packages/synapseclient/table.py in as_table_columns(values)
    410         columnType = DTYPE_2_TABLETYPE[df[col].dtype.char]
    411         if columnType == 'STRING':
--> 412             maxStrLen = df[col].str.len().max()
    413             if maxStrLen > 1000:
    414                 cols.append(Column(name=col, columnType='LARGETEXT', defaultValue=''))

~/miniconda3/lib/python3.7/site-packages/pandas/core/generic.py in __getattr__(self, name)
   5268             or name in self._accessors
   5269         ):
-> 5270             return object.__getattribute__(self, name)
   5271         else:
   5272             if self._info_axis._can_hold_identifiers_and_holds_name(name):

~/miniconda3/lib/python3.7/site-packages/pandas/core/accessor.py in __get__(self, obj, cls)
    185             # we're accessing the attribute of the class, i.e., Dataset.geo
    186             return self._accessor
--> 187         accessor_obj = self._accessor(obj)
    188         # Replace the property with the accessor object. Inspired by:
    189         # http://www.pydanny.com/cached-property.html

~/miniconda3/lib/python3.7/site-packages/pandas/core/strings.py in __init__(self, data)
   2037 
   2038     def __init__(self, data):
-> 2039         self._inferred_dtype = self._validate(data)
   2040         self._is_categorical = is_categorical_dtype(data)
   2041         self._is_string = data.dtype.name == "string"

~/miniconda3/lib/python3.7/site-packages/pandas/core/strings.py in _validate(data)
   2094 
   2095         if inferred_dtype not in allowed_types:
-> 2096             raise AttributeError("Can only use .str accessor with string values!")
   2097         return inferred_dtype
   2098 

AttributeError: Can only use .str accessor with string values!
```