### PR TITLE
Allow update_tables script to be used with service catalog scheduled jobs

### DIFF
--- a/scripts/update_tables.py
+++ b/scripts/update_tables.py
@@ -6,6 +6,7 @@ target table to the target tables as specified in --table-mapping.
 """
 
 import json
+import os
 import argparse
 import logging
 import synapseclient as sc
@@ -27,6 +28,14 @@ def configure_logging(level=logging.INFO):
 def read_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--synapse-access-token")
+    parser.add_argument(
+        "--scheduled-job",
+        help=(
+            "Set to 'enabled' to use Scheduled Job secrets for auth. "
+            "Reads SCHEDULED_JOB_SECRETS JSON from environment and uses key "
+            "SYNAPSE_ACCESS_TOKEN."
+        ),
+    )
     parser.add_argument("--study", help="The Bridge study name to filter upon.")
     parser.add_argument(
         "--reference-table",
@@ -60,7 +69,41 @@ def read_args():
     return args
 
 
+def get_synapse_access_token(args):
+    if args.scheduled_job is not None and args.scheduled_job != "enabled":
+        raise ValueError("--scheduled-job must be set to 'enabled' when provided.")
+
+    if args.scheduled_job == "enabled":
+        secrets_blob = os.getenv("SCHEDULED_JOB_SECRETS")
+        if not secrets_blob:
+            raise ValueError(
+                "--scheduled-job was set but SCHEDULED_JOB_SECRETS is not set."
+            )
+        try:
+            secrets = json.loads(secrets_blob)
+        except json.JSONDecodeError as e:
+            raise ValueError("SCHEDULED_JOB_SECRETS is not valid JSON.") from e
+        token = secrets.get("SYNAPSE_ACCESS_TOKEN")
+        if not token:
+            raise ValueError("SCHEDULED_JOB_SECRETS is missing SYNAPSE_ACCESS_TOKEN.")
+        return token
+
+    if not args.synapse_access_token:
+        raise ValueError(
+            "--synapse-access-token must be set unless --scheduled-job is used."
+        )
+    return args.synapse_access_token
+
+
+def log_args(args):
+    logger = logging.getLogger(__name__)
+    args_to_log = vars(args).copy()
+    args_to_log.pop("synapse_access_token", None)
+    logger.info("Parsed arguments: %s", args_to_log)
+
+
 def parse_table_mapping(table_mapping):
+    logger = logging.getLogger(__name__)
     if table_mapping is None:
         raise TypeError("--table-mapping must be set.")
     try:
@@ -68,6 +111,7 @@ def parse_table_mapping(table_mapping):
     except json.JSONDecodeError:
         parsed_table_mapping = None
     if isinstance(parsed_table_mapping, (dict, list, str)):
+        logger.info("Parsed table mapping: %s", parsed_table_mapping)
         return parsed_table_mapping
     # If JSON parses to a scalar (e.g. number/bool/null), treat input as raw text
     # so plain, non-JSON usage remains supported.
@@ -77,7 +121,9 @@ def parse_table_mapping(table_mapping):
     split_mapping = [table_id.strip() for table_id in table_mapping.split(",")]
     split_mapping = [table_id for table_id in split_mapping if table_id]
     if len(split_mapping) > 1:
+        logger.info("Parsed table mapping: %s", split_mapping)
         return split_mapping
+    logger.info("Parsed table mapping: %s", table_mapping)
     return table_mapping
 
 
@@ -126,7 +172,9 @@ def verify_no_new_table_versions(syn):
 def main():
     args = read_args()
     configure_logging(args.log_level)
-    syn = sc.login(authToken=args.synapse_access_token)
+    log_args(args)
+    synapse_access_token = get_synapse_access_token(args)
+    syn = sc.login(authToken=synapse_access_token)
     table_mapping = parse_table_mapping(args.table_mapping)
     if args.target_project and isinstance(table_mapping, dict):
         table_mapping = list(table_mapping.keys())

--- a/scripts/update_tables.py
+++ b/scripts/update_tables.py
@@ -183,13 +183,28 @@ def main():
     relevant_healthcodes = get_relevant_healthcodes(
         syn=syn, reference_table=args.reference_table, study=args.study
     )
-    synapsebridgehelpers.export_tables(
-        syn=syn,
-        table_mapping=table_mapping,
-        target_project=args.target_project,
-        identifier_col="healthCode",
-        identifier=relevant_healthcodes,
-    )
+    try:
+        synapsebridgehelpers.export_tables(
+            syn=syn,
+            table_mapping=table_mapping,
+            target_project=args.target_project,
+            identifier_col="healthCode",
+            identifier=relevant_healthcodes,
+        )
+    except Exception as e:
+        if args.scheduled_job != "enabled":
+            raise
+        error_message = (
+            f"An error occurred during table export: {str(e)}\n\n"
+            "Please inspect the scheduled job logs in the service catalog."
+        )
+        logging.error(error_message)
+        syn.sendMessage(
+            [syn.getUserProfile()["ownerId"]],
+            "mPower table export failure",
+            error_message,
+        )
+        raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request enhances the authentication process in the `scripts/update_tables.py` script by adding support for using scheduled job secrets to retrieve the Synapse access token, improving flexibility and security when running the script in automated environments. The main changes include introducing a new command-line argument, implementing logic to extract credentials from environment variables, and updating the login flow accordingly.

**Authentication improvements:**

* Added a new `--scheduled-job` command-line argument to enable authentication using secrets provided via the `SCHEDULED_JOB_SECRETS` environment variable, allowing for secure, automated credential management.
* Implemented the `get_synapse_access_token` function to handle retrieval and validation of the Synapse access token from either the command-line argument or the scheduled job secrets, including error handling for missing or malformed secrets.
* Updated the main login flow to use the new `get_synapse_access_token` function, ensuring the correct token source is used based on user input.